### PR TITLE
fix(rustic-babel): disable toolchain when invalid/unneeded

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -58,6 +58,21 @@ considered."
 
 (defvar rustic-babel-spinner nil)
 
+(defun rustic-babel-cargo-params (toolchain)
+  "Return a list of cargo commands for babel evaluation.
+If TOOLCHAIN has a value other than `nil' or `+', then add
+TOOLCHAIN to the list, else return a list of cargo commands with
+no toolchain. Users may need non-toolchain when the computing
+environment installed Cargo with a method other than rustup such
+as with an operating system's package manager, in which case
+Cargo has no support for toolchain specification."
+  (remove nil (list "cargo"
+                    (unless (or (null toolchain)
+                                (equal "+" toolchain))
+                      toolchain)
+                    "build"
+                    "--quiet")))
+
 (defun rustic-babel-eval (dir toolchain-kw-or-string main-p)
   "Start a rust babel compilation process.
 Compilation is started in directory DIR with appropriate
@@ -69,9 +84,12 @@ should be wrapped in which case we will disable rustfmt."
           (toolchain (cond ((eq toolchain-kw-or-string 'nightly) "+nightly")
                            ((eq toolchain-kw-or-string 'beta) "+beta")
                            ((eq toolchain-kw-or-string 'stable) "+stable")
+                           ((or (null rustic-babel-default-toolchain)
+                                (eq 0 (string-blank-p rustic-babel-default-toolchain)))
+                            nil)
                            (toolchain-kw-or-string (format "+%s" toolchain-kw-or-string))
                            (t (format "+%s" rustic-babel-default-toolchain))))
-          (params (list "cargo" toolchain "build" "--quiet"))
+          (params (rustic-babel-cargo-params toolchain))
           (inhibit-read-only t))
      (rustic-compilation-setup-buffer err-buff dir 'rustic-compilation-mode)
      (when rustic-babel-display-compilation-buffer
@@ -122,7 +140,7 @@ execution with rustfmt."
 
            ;; run project
            (let* ((err-buff (get-buffer-create rustic-babel-compilation-buffer-name))
-                  (params (list "cargo" toolchain "run" "--quiet"))
+                  (params (rustic-babel-cargo-params toolchain))
                   (inhibit-read-only t))
              (rustic-make-process
               :name rustic-babel-process-name


### PR DESCRIPTION
Description by @yuuyins from https://github.com/brotzeit/rustic/pull/499  :
When the user installs Rust tools using a method other than rustup, e.g. using an operating system's package manager, cargo generally has no support for toolchain specification. In such case, the user can then `nil`, or `""`, so that the respective functions in `rustic-babel` will remove the toolchain from params, i.e. only toolchain has a valid value if Cargo has toolchain support.

See also: https://github.com/brotzeit/rustic/pull/279#issuecomment-1336164427

Fixes https://github.com/brotzeit/rustic/issues/498 introduced in 80d05c4152a05c1a1de1e99cf4a9eeb95fb734d3
