### PR TITLE
Make `rustic-format-start-process' work over tramp.

### DIFF
--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -116,14 +116,15 @@ and it's `cdr' is a list of arguments."
           (command (or (plist-get args :command)
                        (rustic-compute-rustfmt-args)))
           (command (if (listp command) command (list command)))
-          (cur-buf (current-buffer)))
+          (cur-buf (current-buffer))
+          (rustfmt (rustic-rustfmt-bin)))
      (setq rustic-save-pos (set-marker (make-marker) (point) (current-buffer)))
      (rustic-compilation-setup-buffer err-buf dir 'rustic-format-mode t)
      (--each files
        (unless (file-exists-p it)
          (error (format "File %s does not exist." it))))
      (with-current-buffer err-buf
-       (let* ((c `(,(rustic-rustfmt-bin)
+       (let* ((c `(,rustfmt
                    ,@(split-string rustic-rustfmt-args)
                    ,@command "--" ,@files))
               (proc (rustic-make-process :name rustic-format-process-name


### PR DESCRIPTION
Description from @sp1ff in https://github.com/brotzeit/rustic/pull/522 :

`rustic-rustfmt-bin' selects the rustfmt binary to run depending on whether the current buffer is local (in which case `rustic-rustfmt-bin' will be used) or remote
(`rustic-rustfmt-bin-remote').

`rustic-format-start-process' invokes `rustic-rustfmt-bin' inside a `with-current-buffer' form that makes the error buffer current, which will always seem local, regardless of whether the buffer being formatted is local or not

This patch invokes `rustic-rustfmt-bin' as one of the let bindings so that the correct binary will be selected.