### PR TITLE
Update package-archives modification code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ to fix this.
 
 ``` emacs-lisp
 (require 'package)
-(setq package-archives '(("melpa" . "http://melpa.org/packages/")
-                         ("gnu" . "http://elpa.gnu.org/packages/")))
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
 (package-initialize)
 (package-refresh-contents)
 


### PR DESCRIPTION
Firstly, use `add-to-list` rather than `setq` so that existing
archives aren’t affected.  In particular, Emacs includes NonGNU
ELPA on the list and current instructions remove that archive.

Secondly, prefer https over http when specifying URL of MELPA.
