### PR TITLE
Babel uses rustic cargo bin

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -71,7 +71,7 @@ should be wrapped in which case we will disable rustfmt."
                            ((eq toolchain-kw-or-string 'stable) "+stable")
                            (toolchain-kw-or-string (format "+%s" toolchain-kw-or-string))
                            (t (format "+%s" rustic-babel-default-toolchain))))
-          (params (list "cargo" toolchain "build" "--quiet"))
+          (params (list (rustic-cargo-bin) toolchain "build" "--quiet"))
           (inhibit-read-only t))
      (rustic-compilation-setup-buffer err-buff dir 'rustic-compilation-mode)
      (when rustic-babel-display-compilation-buffer
@@ -122,7 +122,7 @@ execution with rustfmt."
 
            ;; run project
            (let* ((err-buff (get-buffer-create rustic-babel-compilation-buffer-name))
-                  (params (list "cargo" toolchain "run" "--quiet"))
+                  (params (list (rustic-cargo-bin) toolchain "run" "--quiet"))
                   (inhibit-read-only t))
              (rustic-make-process
               :name rustic-babel-process-name
@@ -214,7 +214,7 @@ after successful compilation."
 Return full path if EXPAND is t."
   (let* ((default-directory rustic-org-babel-temporary-directory)
          (dir (make-temp-file-internal "cargo" 0 "" nil)))
-    (shell-command-to-string (format "cargo new %s --bin --quiet" dir))
+    (shell-command-to-string (format "%s new %s --bin --quiet" (rustic-cargo-bin) dir))
     (if expand
         (concat (expand-file-name dir) "/")
       dir)))

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -405,7 +405,7 @@ at least one time in this emacs session before this command can be used."
           (default-directory rustic-org-babel-temporary-directory)
           (body (org-element-property :value (org-element-at-point)))
           (project (rustic-babel-project))
-          (params (list "cargo" "clippy")))
+          (params (list (rustic-cargo-bin) "clippy")))
      (let* ((dir (setq rustic-babel-dir (expand-file-name project)))
             (main (expand-file-name "main.rs" (concat dir "/src")))
             (default-directory dir))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -363,7 +363,7 @@ Execute process in PATH."
 
 (defun rustic-cargo-install-crate-p (crate)
   "Ask whether to install crate CRATE."
-  (let ((cmd (format "cargo install cargo-%s" crate)))
+  (let ((cmd (format "%s install cargo-%s" (rustic-cargo-bin) crate)))
     (when (yes-or-no-p (format "Cargo-%s missing. Install ? " crate))
       (async-shell-command cmd (rustic-cargo-bin) "cargo-error"))))
 
@@ -522,7 +522,7 @@ The CRATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
   (let (upgrade)
     (dolist (crate crates)
       (setq upgrade (concat upgrade (format "-p %s@%s " (rustic-crate-name crate) (rustic-crate-version crate)))))
-    (let ((output (shell-command-to-string (format "cargo upgrade --offline %s" upgrade))))
+    (let ((output (shell-command-to-string (format "%s upgrade --offline %s" (rustic-cargo-bin) upgrade))))
       (if (string-match "error: no such subcommand:" output)
           (rustic-cargo-install-crate-p "edit")
         (rustic-cargo-reload-outdated)))))

--- a/rustic-comint.el
+++ b/rustic-comint.el
@@ -112,7 +112,8 @@ Read the full command from the minibuffer when ARG is non-nil or
 when called with a prefix command \\[universal-argument]."
   (interactive "P")
   (let* ((command (if arg
-                      (read-from-minibuffer "Cargo run command: " "cargo run -- ")
+                      (read-from-minibuffer "Cargo run command: "
+                                            (concat (rustic-cargo-bin) " run -- "))
                     (concat (rustic-cargo-bin) " run "
                             (setq rustic-run-arguments
                                   (read-from-minibuffer

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -299,11 +299,11 @@ If NOCONFIRM is non-nil, install all dependencies without prompting user."
       (when (and (or missing-fd missing-makedocs missing-rg)
                  (or noconfirm (y-or-n-p "Missing some dependencies for rustic doc, install them? ")))
         (when missing-fd
-          (rustic-doc--start-process "install-fd" "cargo" nil "install" "fd-find"))
+          (rustic-doc--start-process "install-fd" (rustic-cargo-bin) nil "install" "fd-find"))
         (when missing-rg
-          (rustic-doc--start-process "install-rg" "cargo" nil "install" "ripgrep"))
+          (rustic-doc--start-process "install-rg" (rustic-cargo-bin)  nil "install" "ripgrep"))
         (when missing-makedocs
-          (rustic-doc--start-process "install-makedocs" "cargo" nil
+          (rustic-doc--start-process "install-makedocs" (rustic-cargo-bin) nil
                                      "install" "cargo-makedocs"))))))
 
 ;;;###autoload

--- a/rustic-popup.el
+++ b/rustic-popup.el
@@ -149,7 +149,7 @@ If directory is not in a rust project call `read-directory-name'."
            (c (intern (concat "rustic-cargo-" command))))
       (if (commandp c)
           (call-interactively c)
-        (call-interactively 'rustic-compile (concat "cargo " command)))))
+        (call-interactively 'rustic-compile (concat (rustic-cargo-bin) " " command)))))
   (when rustic-kill-buffer-and-window
     (kill-buffer-and-window)))
 
@@ -220,7 +220,7 @@ corresponding line."
 
 (defun rustic-popup-help-flags (command)
   "Get flags of COMMAND."
-  (let ((string (shell-command-to-string (format "cargo %s -h" command)))
+  (let ((string (shell-command-to-string (format "%s %s -h" (rustic-cargo-bin) command)))
         flags)
     (dolist (s (split-string string "\n"))
       (when (and (not (string-match "^\s+\-h" s))


### PR DESCRIPTION
Description from @easye in https://github.com/brotzeit/rustic/pull/525:

If the "cargo" executable is not in the PATH, the org babel code will not work. This was the case for me on macOS using rustup under Emacs.app, where the per-user PATH settings are not easily configured.