### PR TITLE
fix(rustic-babel-build-sentinel): align behaviour with other lang

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -112,7 +112,8 @@ execution with rustfmt."
    (let ((proc-buffer (process-buffer proc))
          (inhibit-read-only t))
      (if (zerop (process-exit-status proc))
-         (let* ((default-directory rustic-babel-dir))
+         (let* ((original-default-directory default-directory)
+                (default-directory rustic-babel-dir))
 
            ;; format babel block
            (when (and rustic-babel-format-src-block (not rustic-babel-auto-wrap-main) (not main-p))
@@ -121,9 +122,21 @@ execution with rustfmt."
                  (sit-for 0.1))))
 
            ;; run project
-           (let* ((err-buff (get-buffer-create rustic-babel-compilation-buffer-name))
-                  (params (list "cargo" toolchain "run" "--quiet"))
-                  (inhibit-read-only t))
+           (let* ((err-buff
+                 (get-buffer-create rustic-babel-compilation-buffer-name))
+                (params
+                 (list
+                  "cargo"
+                  toolchain
+                  "run"
+                  "--manifest-path"
+                  (format "%s/Cargo.toml" rustic-babel-dir)
+                  "--quiet"))
+                (inhibit-read-only t)
+                ;; command should run in the original default-directory
+                ;; which is typically the original org file
+                ;; This agrees with behaviour of C, C++, D, js, python, etc.
+                (default-directory original-default-directory))
              (rustic-make-process
               :name rustic-babel-process-name
               :buffer err-buff


### PR DESCRIPTION
Original description from @ed9w2in6 in https://github.com/brotzeit/rustic/pull/535 :

In an org file, the src block's code should be interpreted, OR the binary compiled from it SHOULD execute with PWD as `default-directory` of the org file.

Summary of changes: 
1. save the original default-directory then later restores it.
2. supply `--manifest-path` option to `cargo run` to execute the target `Cargo.toml` binary compiled from the src block.

For reference:
Try to execute a C++, C, js (node), python block.
In particular, see implementation of `org-babel-C-execute` or `org-babel-python-evaluate-external-process`.  May be we can re-write like them in the future.

fixes: https://github.com/brotzeit/rustic/issues/509