### PR TITLE
syntax error in rustic-cargo-add with prefix argument

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -748,11 +748,10 @@ The documentation is built if necessary."
   "Add crate to Cargo.toml using 'cargo add'.
 If running with prefix command `C-u', read whole command from minibuffer."
   (interactive "P")
-  (let* ((command (if arg
-                      (read-from-minibuffer "Cargo add command: "
-                                            (rustic-cargo-bin) " add ")
-                    (concat (rustic-cargo-bin) " add "
-                            (read-from-minibuffer "Crate: ")))))
+  (let* ((base (concat (rustic-cargo-bin) " add "))
+         (command (if arg
+                      (read-from-minibuffer "Cargo add command: " base)
+                    (concat base (read-from-minibuffer "Crate: ")))))
     (rustic-run-cargo-command command)))
 
 (defun rustic-cargo-add-missing-dependencies (&optional arg)


### PR DESCRIPTION
Original description by @sigvei in https://github.com/brotzeit/rustic/pull/536:

rustic-cargo-add with a prefix command called read-from-minibuffer with erroneous arguments.

The current master produces this error message:

funcall-interactively: Wrong type argument: keymapp, " add "

This is due to the line (read-from-minibuffer "Cargo add command: " (rustic-cargo-bin) " add "), which makes " add " a third argument to read-from-minibuffer. I guess it's suppose to just be concated with rustic-cargo-bin.

This commit implements that and also DRY's the code by storing the base command in a let binding.