### PR TITLE
Fix cargo new for non-existing directory

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -528,6 +528,16 @@ The CRATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
         (rustic-cargo-reload-outdated)))))
 
 ;;; New project
+(defun rustic--split-path (project-path)
+  "Split PROJECT-PATH into two parts: the longest prefix of directories that
+exist, and the rest. Return a cons cell of the two parts."
+  (let ((components (file-name-split project-path))
+        (existing-dir ""))
+    (while (and (not (null components))
+                (file-directory-p (file-name-concat existing-dir (car components))))
+      (setq existing-dir (file-name-concat existing-dir (car components)))
+      (setq components (cdr components)))
+    (cons existing-dir (apply 'file-name-concat (cons "" components)))))
 
 (defun rustic-create-project (project-path is-new &optional bin)
   "Run either 'cargo new' if IS-NEW is non-nil, or 'cargo init' otherwise.
@@ -547,10 +557,12 @@ BIN is not nil, create a binary application, otherwise a library."
                                                     "/src/main.rs"
                                                   "/src/lib.rs")))))))
          (proc (format "rustic-cargo-%s-process" cmd))
-         (buf (format "*cargo-%s*" cmd)))
+         (buf (format "*cargo-%s*" cmd))
+         (dir-pair (rustic--split-path project-path))
+         (default-directory (car dir-pair)))
     (make-process :name proc
                   :buffer buf
-                  :command (list (rustic-cargo-bin) cmd bin project-path)
+                  :command (list (rustic-cargo-bin) cmd bin (cdr dir-pair))
                   :sentinel new-sentinel
                   :file-handler t)))
 
@@ -558,7 +570,7 @@ BIN is not nil, create a binary application, otherwise a library."
 (defun rustic-cargo-new (project-path &optional bin)
   "Run 'cargo new' to start a new package in the path specified by PROJECT-PATH.
 If BIN is not nil, create a binary application, otherwise a library."
-  (interactive "DProject path: ")
+  (interactive "GProject path: ")
   (rustic-create-project project-path t bin))
 
 ;;;###autoload


### PR DESCRIPTION
Original description by @roife in https://github.com/brotzeit/rustic/pull/540 :

fix https://github.com/brotzeit/rustic/issues/506.

The current implementation of rustic-cargo-new utilizes D within interactive, necessitating an existing path. However, the functionality of cargo new allows arguments for non-existing paths and automatically generates directories.

For instance, when executing cargo new a1/a2 within ~/source, Cargo generates a directory named a1 and a subdirectory a2 within a1. Subsequently, cargo new initializes a package within ~/source/a1/a2.

This proposed patch aims to enhance rustic-cargo-new by enabling acceptance of arbitrary paths. It will then determine the longest existing prefix of the path as the default-directory, utilizing the remainder as the project-name passed to cargo new.