### PR TITLE
add language id for eglot

### DIFF
--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -106,8 +106,6 @@ with `lsp-rust-switch-server'."
 ;;; eglot support
 
 (defvar eglot-ignored-server-capabilites)
-(defvar eglot-ignored-server-capabilites)
-(defvar eglot-server-programs)
 (defvar eglot-server-programs)
 (declare-function eglot-ensure "eglot" ())
 
@@ -125,7 +123,7 @@ with `lsp-rust-switch-server'."
                                      (when (symbolp (car mode))
                                        (eq (car mode) 'rust-mode)))
                                    eglot-server-programs)))))
-    (add-to-list 'eglot-server-programs `(rustic-mode . (eglot-rust-analyzer . ,rustic-analyzer-command)))))
+    (add-to-list 'eglot-server-programs `((rustic-mode :language-id "rust") . (eglot-rust-analyzer . ,rustic-analyzer-command)))))
 
 (with-eval-after-load 'eglot
   (defclass eglot-rust-analyzer (eglot-lsp-server) ()


### PR DESCRIPTION
Original description by @roife https://github.com/brotzeit/rustic/pull/542 :



Set proper :language-id.

If it is not set properly, the language id eglot found will be rustic, which is not described in standard and causes rust-analyzer frequently crash.
