### PR TITLE
Use xterm-color-names in rustic compilation buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ FTR #174 #179 #236
 
 The colors that are displayed in compilation buffers come from cargo
 and are translated by xterm-color. You can change these colors by
-modifying `rustic-ansi-faces`.
+modifying `xterm-color-names` and `xterm-color-names-bright`.
 
 `rustic-compilation-mode` doesn't use the default faces of
 compile.el. If you want to change these colors you can use something

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -115,18 +115,6 @@
   "Override `compilation-column-face' for rust compilation."
   :group 'rustic-compilation)
 
-(defcustom rustic-ansi-faces ["black"
-                              "red3"
-                              "green3"
-                              "yellow3"
-                              "blue2"
-                              "magenta3"
-                              "cyan3"
-                              "white"]
-  "Term ansi faces."
-  :type '(vector string string string string string string string string)
-  :group 'rustic-compilation)
-
 ;;; Compilation-mode
 
 (defvar rustic-compilation-mode-map
@@ -183,9 +171,6 @@ Error matching regexes from compile.el are removed."
   (setq-local compilation-info-face    'rustic-compilation-info)
   (setq-local compilation-column-face  'rustic-compilation-column)
   (setq-local compilation-line-face    'rustic-compilation-line)
-
-  (setq-local xterm-color-names-bright rustic-ansi-faces)
-  (setq-local xterm-color-names rustic-ansi-faces)
 
   (setq-local compilation-error-regexp-alist-alist nil)
   (add-to-list 'compilation-error-regexp-alist-alist


### PR DESCRIPTION
Closes #16 

Currently rustic overrides the default xterm colors with custom colors in `rustic-ansi-faces`. But many themes will set the xterm-colors to match the pallet. By just using the users xterm colors it makes the package easier to configure. 