### PR TITLE
Fix cargo-clippy rerun to remember its arguments

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,3 +21,4 @@
 - ~rustic-recompile~ will remember any universal arguments that is
   passed to it.
 - Fix ~rustic-cargo-upgrade~ in the presence of universal arguments.
+- Fix ~rusti-cargo-clippy-rerun~ to use the last used arguments.

--- a/rustic-clippy.el
+++ b/rustic-clippy.el
@@ -98,7 +98,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-clippy-rerun ()
   "Run 'cargo clippy' with `rustic-clippy-arguments'."
   (interactive)
-  (rustic-cargo-clippy-run rustic-clippy-arguments))
+  (rustic-cargo-clippy-run :params rustic-clippy-arguments))
 
 (defun rustic-cargo-clippy-fix (&rest args)
   "Run 'clippy fix'."


### PR DESCRIPTION
Fixes #22 