### PR TITLE
cargo: improve and unify function regexp

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -227,7 +227,7 @@ If ARG is not nil, use value as argument and store it in
 (defconst rustic-cargo-mod-regexp
   "^\s*mod\s+\\([[:word:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*\\)\s*{")
 (defconst rustic-cargo-fn-regexp
-  "^\s*\\(?:async\s+\\)?\s*fn\s+\\([^(]+\\)\s*(")
+  (concat rustic-func-item-beg-re "\\([^(<]+\\)\\s-*\\(?:<\\s-*.+\\s-*>\\s-*\\)?("))
 
 (defun rustic-cargo--get-test-target()
   "Return either a full fn name or a mod name, whatever is closer to the point."

--- a/rustic-interaction.el
+++ b/rustic-interaction.el
@@ -31,8 +31,15 @@ visiting a project."
 ;;       that we added an extra regexp for funcs.
 
 (defvar rustic-func-item-beg-re
-  (concat "\\s-*\\(?:priv\\|pub\\)?\\s-*\\(?:async\\)?\\s-*"
-          (regexp-opt '("fn")))
+  (concat "^"
+          "\\(?:\\s-*"
+          (regexp-opt '("priv" "pub")) "\\s-*"
+          "\\(?:(\\s-*\\(?:in\\s-+\\)?" (regexp-opt '("crate" "self" "super")) "\\s-*)\\)?"
+          "\\)?"
+          "\\(?:\\s-*" (regexp-opt '("async" "const")) "\\s-+\\)?"
+          "\\(?:\\s-*unsafe\\s-+\\)?"
+          "\\(?:\\s-*extern\\(?:\\s-+\"C\"\\)?\\s-+\\)?"
+          "\\s-*fn\\s-+")
   "Start of a rust function.")
 
 (defun rustic-beginning-of-function ()

--- a/test/rustic-cargo-test.el
+++ b/test/rustic-cargo-test.el
@@ -90,6 +90,212 @@ fn test1() {
     (setq rustic-test-arguments "")
     (kill-buffer buf)))
 
+(ert-deftest rustic-test-cargo-current-test-pub ()
+  (let* ((string "#[test]
+fn test1() {
+}
+#[test]
+pub fn test2() {
+}")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 4)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should-not (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-pub-in-crate ()
+  (let* ((string "#[test]
+fn test1() {
+}
+#[test]
+pub(in crate) fn test2() {
+}")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 4)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should-not (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-pub-self ()
+  (let* ((string "#[test]
+fn test1() {
+}
+#[test]
+ pub( self) fn test2() {
+}")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 4)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should-not (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-pub-super ()
+  (let* ((string "#[test]
+  pub  (super ) fn test1() {
+  }
+  #[test]
+ fn test2() {
+ }")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 1)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should-not (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-const ()
+  (let* ((string "#[test]
+ const fn test1() {
+  }
+  #[test]
+ fn test2() {
+ }")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 1)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should-not (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-unsafe ()
+  (let* ((string "#[test]
+ unsafe fn test1() {
+  }
+  #[test]
+ fn test2() {
+ }")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 1)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should-not (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-extern ()
+  (let* ((string "#[test]
+  extern \"C\" fn test1() {
+  }
+  #[test]
+ fn test2() {
+ }")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 1)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should-not (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-test-diamond ()
+  (let* ((string "#[test]
+fn test1() {
+}
+#[test]
+ fn test2<'a>() {
+}")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 4)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should-not (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
+(ert-deftest rustic-test-cargo-current-combined ()
+  (let* ((string "#[test]
+fn test1() {
+}
+pub(in self) const unsafe extern fn test2 <T >() {
+}")
+         (default-directory (rustic-test-count-error-helper string))
+         (buf (get-buffer-create "test-current-test")))
+    (with-current-buffer buf
+      (insert string)
+      (goto-char (point-min))
+      (forward-line 4)
+      (let* ((proc (rustic-cargo-current-test))
+             (proc-buf (process-buffer proc)))
+        (rustic-test--wait-till-finished rustic-test-buffer-name)
+        (with-current-buffer proc-buf
+          (should-not (string-match "test1" (buffer-substring-no-properties (point-min) (point-max))))
+          (should (string-match "test2" (buffer-substring-no-properties (point-min) (point-max)))))
+        (kill-buffer proc-buf)))
+    (setq rustic-test-arguments "")
+    (kill-buffer buf)))
+
 (ert-deftest rustic-test-cargo-current-test-no-test-found ()
   ;; test with use #46
   (let* ((string "mod tests {


### PR DESCRIPTION
Far from complete but reasonable amount of function syntax added.
Partial(since matching still occurs twice) unification solves signature-name search discrepancies.
