### PR TITLE
Fix panic regex

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -153,7 +153,7 @@
   "Create hyperlink in compilation buffers for file paths preceded by ':::'.")
 
 (defvar rustic-compilation-panic
-  (let ((panic "thread '[^']+' panicked at '[^']+', ")
+  (let ((panic "thread '[^']+' panicked at ")
         (file "\\([^\n]+\\)")
         (start-line "\\([0-9]+\\)")
         (start-col  "\\([0-9]+\\)"))

--- a/test/rustic-compile-test.el
+++ b/test/rustic-compile-test.el
@@ -146,4 +146,17 @@
       (with-current-buffer (get-buffer rustic-compilation-buffer-name)
         (should (= compilation-num-errors-found 0))))))
 
+(ert-deftest rustic-test-panic ()
+  (kill-buffer (get-buffer rustic-compilation-buffer-name))
+  (let* ((string "fn main() {
+                       panic!(\"oops!\");
+                    }")
+         (default-directory (rustic-test-count-error-helper string)))
+    (let ((rustic-compile-backtrace "0")
+          (proc (rustic-compilation-start (split-string "cargo run"))))
+      (while (eq (process-status proc) 'run)
+        (sit-for 0.1))
+      (with-current-buffer (get-buffer rustic-compilation-buffer-name)
+        (should (= compilation-num-errors-found 0))))))
+
 (provide 'rustic-compile-test)

--- a/test/rustic-compile-test.el
+++ b/test/rustic-compile-test.el
@@ -157,6 +157,6 @@
       (while (eq (process-status proc) 'run)
         (sit-for 0.1))
       (with-current-buffer (get-buffer rustic-compilation-buffer-name)
-        (should (= compilation-num-errors-found 0))))))
+        (should (= compilation-num-errors-found 1))))))
 
 (provide 'rustic-compile-test)


### PR DESCRIPTION
Fix `rustic-compilation-panic` regex by removing  `'[^']+',` to solve brotzeit/rustic#573.