### PR TITLE
Fix void-variable error in rustic-cargo-spellcheck-mode

### DIFF
--- a/rustic-spellcheck.el
+++ b/rustic-spellcheck.el
@@ -78,9 +78,6 @@ Error matching regexes from compile.el are removed."
   (setq-local compilation-column-face  'rustic-compilation-column)
   (setq-local compilation-line-face    'rustic-compilation-line)
 
-  (setq-local xterm-color-names-bright rustic-ansi-faces)
-  (setq-local xterm-color-names rustic-ansi-faces)
-
   (setq-local compilation-error-regexp-alist-alist nil)
   (add-to-list 'compilation-error-regexp-alist-alist
                (cons 'rustic-spell-error rustic-spellcheck-error))


### PR DESCRIPTION
This is a follow-up to emacs-rustic/rustic#17.