### PR TITLE
Switch to the rustfmt error buffer after spawning the rustfmt process

### DIFF
--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -123,16 +123,16 @@ and it's `cdr' is a list of arguments."
      (--each files
        (unless (file-exists-p it)
          (error (format "File %s does not exist." it))))
-     (with-current-buffer err-buf
-       (let* ((c `(,rustfmt
-                   ,@(split-string rustic-rustfmt-args)
-                   ,@command "--" ,@files))
-              (proc (rustic-make-process :name rustic-format-process-name
-                                         :buffer err-buf
-                                         :command (remove "" c)
-                                         :filter #'rustic-compilation-filter
-                                         :sentinel sentinel
-                                         :file-handler t)))
+     (let* ((c `(,rustfmt
+                 ,@(split-string rustic-rustfmt-args)
+                 ,@command "--" ,@files))
+            (proc (rustic-make-process :name rustic-format-process-name
+                                       :buffer err-buf
+                                       :command (remove "" c)
+                                       :filter #'rustic-compilation-filter
+                                       :sentinel sentinel
+                                       :file-handler t)))
+       (with-current-buffer err-buf
          (setq next-error-last-buffer buffer)
          (when string
            (process-put proc 'command-buf cur-buf)


### PR DESCRIPTION
The preexisting code switches to the error buffer before constructing the rustfmt command line. In the event that there is a buffer-local value for any of the applicable variables (e.g. `rustic-rustfmt-args`), it is effectively ignored because the variables are taken from the context of the error buffer, rather than the working buffer.