### PR TITLE
Add basic var support to the org-src blocks.

### DIFF
--- a/test/rustic-babel-test.el
+++ b/test/rustic-babel-test.el
@@ -271,4 +271,28 @@
       (rustic-test-babel-execute-block buf)
       (should (eq (rustic-test-babel-check-results buf) nil)))))
 
+(ert-deftest rustic-test-babel-block-with-simple-var ()
+  (let* ((string "println!(\"{}\", A)")
+         (params ":main yes :var A=\"A\"")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (should (string-equal (rustic-test-babel-check-results buf) "A\n")))))
+
+(ert-deftest rustic-test-babel-block-with-list-var ()
+  (let* ((string "println!(\"{:?}\", A)")
+         (params ":main yes :var A='(\"A\" \"B\")")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (should (string-equal (rustic-test-babel-check-results buf) "[\"A\", \"B\"]\n")))))
+
+(ert-deftest rustic-test-babel-block-with-nested-list-var ()
+  (let* ((string "println!(\"{:?}\", A)")
+         (params ":main yes :var A='((\"A\" \"B\") (\"C\" \"D\"))")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (should (string-equal (rustic-test-babel-check-results buf) "[[\"A\", \"B\"], [\"C\", \"D\"]]\n")))))
+
 (provide 'rustic-babel-test)


### PR DESCRIPTION
This will just wrap the variables into &str (or &[&str]) constants.

It will also not care about the types of the passed variables, except if they are lists - all other type information doesn't matter - everything will be a &str in the end.

Example:

```
#+name: mytbl
| A | B |
|---+---|
| a | b |
| c | d |
|   | g |
| e | f |

#+begin_src rust :var A=mytbl :var B='("b" "c") :var C="c"
println!("{:?}", A);
println!("{:?}", B);
println!("{:?}", C);
#+end_src

#+RESULTS:
: [["a", "b"], ["c", "d"], ["", "g"], ["e", "f"]]
: ["b", "c"]
: "c"
```
