### PR TITLE
Fix RUSTIC-CARGO-TEST

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -229,15 +229,21 @@ If ARG is not nil, use value as argument and store it in
 `rustic-popup-mode', always use the value of
 `rustic-test-arguments'."
   (interactive "P")
-  (when arg
-    (setq rustic-test-arguments
-          (read-from-minibuffer "Cargo test arguments: "
-                                (rustic--populate-minibuffer
-                                 (list (rustic-cargo-package-argument)
-                                       rustic-test-arguments
-                                       rustic-cargo-build-arguments
-                                       rustic-default-test-arguments)))))
-  (rustic-cargo-test-run rustic-test-arguments))
+  (rustic-cargo-test-run
+   (cond (arg
+          (setq rustic-test-arguments
+                (read-from-minibuffer "Cargo test arguments: "
+                                      (rustic--populate-minibuffer
+                                       (list (rustic-cargo-package-argument)
+                                             rustic-test-arguments
+                                             rustic-cargo-build-arguments
+                                             rustic-default-test-arguments)))))
+         (rustic-cargo-use-last-stored-arguments
+          (if (> (length rustic-test-arguments) 0)
+              rustic-test-arguments
+            rustic-default-test-arguments))
+         (t
+          rustic-default-test-arguments))))
 
 ;;;###autoload
 (defun rustic-cargo-test-rerun ()

--- a/test/rustic-cargo-test.el
+++ b/test/rustic-cargo-test.el
@@ -445,7 +445,7 @@ fn test() {
           (should (eq major-mode 'rustic-cargo-test-mode)))
         (should (string= (s-join " " (process-get proc 'command))
                          (s-trim (concat (rustic-cargo-bin) " test "
-                                    rustic-test-arguments))))))))
+                                    rustic-default-test-arguments))))))))
 
 (ert-deftest rustic-cargo-expand-test ()
   (let* ((string "fn main() {()}")


### PR DESCRIPTION
To only use the last stored arguments if
RUSTIC-CARGO-USE-LAST-STORED-ARGUMENTS is non-nil.

Otherwise once we run only a single test (e.g via
RUSTIC-CARGO-CURRENT-TEST), then trying to run all tests will still only run the last current test.