### PR TITLE
Fix issue resolving cargo binary without default-directory

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,6 +6,7 @@
 - Replace Cask with Eask for CI testing.
 - Implement ~rustic-cargo-nextest-current-test~ for running test at a
   point using nextest.
+- Fixed an issue where workspaces were not resolved correctly over TRAMP.
 
 * 3.5
 


### PR DESCRIPTION
Hey! Thank you for the great work maintaining this project.

I'm doing a lot of development over TRAMP (along with envrc) and found that `cargo build` was failing. I was able to get this to work as expected by resolving the cargo binary _before_ entering the temporary directory as part of the workspace resolution function, which lets `rustic-cargo-bin` correctly detect `file-remote-p`.