### PR TITLE
Format quoted segments in documentation strings consistently

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -323,13 +323,13 @@ directory DIR."
           (insert dependencies))))))
 
 (defun rustic-babel-ensure-main-wrap (body)
-  "Wrap BODY in a 'fn main' function call if none exists."
+  "Wrap BODY in a `fn main' function call if none exists."
   (if (string-match "^[ \t]*\\(pub \\)?\\(async \\)?[fn]+[ \t\n\r]*main[ \t]*(.*)" body)
       body
     (format "fn main() {\n%s\n}\n" body)))
 
 (defun rustic-babel-include-blocks (blocks)
-  "Insert contents of BLOCKS to the 'main block' that is being
+  "Insert contents of BLOCKS to the `main block' that is being
 executed with the parameter `:include'."
   (let ((contents ""))
     (with-current-buffer (current-buffer)
@@ -366,9 +366,9 @@ executed with the parameter `:include'."
 
 Only supports three cases:
 
-1. Simple value: A='a' -> &str
-2. Simple list: A=('a' 'b') -> &[&str]
-3. Nested list (org-table): A=(('a' 'b')) -> &[&[&str]]"
+1. Simple value: A=\\='a\\=' -> &str
+2. Simple list: A=(\\='a\\=' \\='b\\=') -> &[&str]
+3. Nested list (org-table): A=((\\='a\\=' \\='b\\=')) -> &[&[&str]]"
   (if (listp var)
       (if (listp (car var)) "&[&[&str]]" "&[&str]")
     "&str"))
@@ -394,9 +394,9 @@ to be homogenous."
 
 There are only 3 cases:
 
-1. Simple value: A='a' -> &str
-2. Simple list: A=('a' 'b') -> &[&str]
-2. Nested list (org-table): A=(('a' 'b')) -> &[&[&str]]"
+1. Simple value: A=\\='a\\=' -> &str
+2. Simple list: A=(\\='a\\=' \\='b\\=') -> &[&str]
+2. Nested list (org-table): A=((\\='a\\=' \\='b\\=')) -> &[&[&str]]"
   (string-join
    (mapcar
     (lambda (pair)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -20,27 +20,27 @@
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-check-exec-command "check"
-  "Execute command to run cargo check."
+  "Execute command to run `cargo check'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-test-exec-command "test"
-  "Execute command to run cargo test."
+  "Execute command to run `cargo test'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-nextest-exec-command "nextest run"
-  "Execute command to run nextest."
+  "Execute command to run `nextest'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-run-exec-command "run"
-  "Execute command to run cargo run."
+  "Execute command to run `cargo run'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-build-exec-command "build"
-  "Execute command to run cargo build."
+  "Execute command to run `cargo build'."
   :type 'string
   :group 'rustic-cargo)
 
@@ -95,7 +95,7 @@ If nil then the project is simply created."
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-test-disable-warnings nil
-  "Don't show warnings when running 'cargo test'."
+  "Don't show warnings when running `cargo test'."
   :type 'boolean
   :group 'rustic-cargo)
 
@@ -112,29 +112,29 @@ instead of applying the default arguments from `rustic-default-test-arguments'."
   :group 'rustic-cargo)
 
 (defcustom rustic-default-test-arguments "--benches --tests --all-features"
-  "Default arguments when running 'cargo test'."
+  "Default arguments when running `cargo test'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-default-install-arguments '("--path" "." "--locked")
-  "Default arguments when running 'cargo install'."
+  "Default arguments when running `cargo install'."
   :type '(list string)
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-check-arguments "--benches --tests --all-features"
-  "Default arguments when running 'cargo check'."
+  "Default arguments when running `cargo check'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-build-arguments ""
-  "Default arguments when running 'cargo build'."
+  "Default arguments when running `cargo build'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-auto-add-missing-dependencies nil
   "Automatically adds dependencies to Cargo.toml.
-This way rustic checks new diagnostics for 'unresolved import'
-errors and passes the crates to 'cargo add'.
+This way rustic checks new diagnostics for `unresolved import'
+errors and passes the crates to `cargo add'.
 Currently only working with lsp-mode."
   :type 'boolean
   :group 'rustic-cargo)
@@ -166,12 +166,12 @@ Currently only working with lsp-mode."
   "Buffer name for test buffers.")
 
 (defvar rustic-test-arguments ""
-  "Holds arguments for 'cargo test', similar to `compilation-arguments`.
+  "Holds arguments for `cargo test', similar to `compilation-arguments`.
 Tests that are executed by `rustic-cargo-current-test' will also be
 stored in this variable.")
 
 (defvar rustic-test-history nil
-  "Holds previous arguments for 'cargo test', similar to `compile-arguments`.")
+  "Holds previous arguments for `cargo test', similar to `compile-arguments`.")
 
 (defvar rustic-cargo-test-mode-map
   (let ((map (make-sparse-keymap)))
@@ -203,7 +203,7 @@ If ARG is not nil, get input from minibuffer."
     (rustic-compilation c (list :buffer buf :process proc :mode mode))))
 
 (defun rustic-cargo-nextest-current-test ()
-  "Run 'cargo nextest run' for the test near point."
+  "Run `cargo nextest run' for the test near point."
   (interactive)
   (rustic-compilation-process-live)
   (-if-let (test-to-run (setq rustic-test-arguments
@@ -215,7 +215,7 @@ If ARG is not nil, get input from minibuffer."
 
 ;;;###autoload
 (defun rustic-cargo-test-run (&optional test-args)
-  "Start compilation process for 'cargo test' with optional TEST-ARGS."
+  "Start compilation process for `cargo test' with optional TEST-ARGS."
   (interactive)
   (rustic-compilation-process-live)
   (let* ((command (list (rustic-cargo-bin) rustic-cargo-test-exec-command))
@@ -227,7 +227,7 @@ If ARG is not nil, get input from minibuffer."
 
 ;;;###autoload
 (defun rustic-cargo-test (&optional arg)
-  "Run 'cargo test'.
+  "Run `cargo test'.
 
 If ARG is not nil, use value as argument and store it in
 `rustic-test-arguments'.  When calling this function from
@@ -253,7 +253,7 @@ If ARG is not nil, use value as argument and store it in
 
 ;;;###autoload
 (defun rustic-cargo-test-rerun (arg)
-  "Run 'cargo test' with `rustic-test-arguments'."
+  "Run `cargo test' with `rustic-test-arguments'."
   (interactive "P")
   (let ((default-directory (or rustic-compilation-directory default-directory)))
     (setq rustic-test-arguments
@@ -284,7 +284,7 @@ If ARG is not nil, use value as argument and store it in
 
 ;;;###autoload
 (defun rustic-cargo-current-test ()
-  "Run 'cargo test' for the test near point."
+  "Run `cargo test' for the test near point."
   (interactive)
   (rustic-compilation-process-live)
   (-if-let (test-to-run (setq rustic-test-arguments
@@ -390,7 +390,7 @@ If ARG is not nil, use value as argument and store it in
 
 ;;;###autoload
 (defun rustic-cargo-outdated (&optional path)
-  "Use 'cargo outdated' to list outdated packages in `tabulated-list-mode'.
+  "Use `cargo outdated' to list outdated packages in `tabulated-list-mode'.
 Execute process in PATH."
   (interactive)
   (rustic--inheritenv
@@ -627,7 +627,7 @@ exist, and the rest. Return a cons cell of the two parts."
     (cons existing-dir (apply 'file-name-concat (cons "" components)))))
 
 (defun rustic-create-project (project-path is-new &optional bin)
-  "Run either 'cargo new' if IS-NEW is non-nil, or 'cargo init' otherwise.
+  "Run either `cargo new' if IS-NEW is non-nil, or `cargo init' otherwise.
 Creates or initializes the directory at the path specified by PROJECT-PATH. If
 BIN is not nil, create a binary application, otherwise a library."
   (let* ((cmd (if is-new "new" "init"))
@@ -655,14 +655,14 @@ BIN is not nil, create a binary application, otherwise a library."
 
 ;;;###autoload
 (defun rustic-cargo-new (project-path &optional bin)
-  "Run 'cargo new' to start a new package in the path specified by PROJECT-PATH.
+  "Run `cargo new' to start a new package in the path specified by PROJECT-PATH.
 If BIN is not nil, create a binary application, otherwise a library."
   (interactive "GProject path: ")
   (rustic-create-project project-path t bin))
 
 ;;;###autoload
 (defun rustic-cargo-init (project-path &optional bin)
-  "Run 'cargo init' to initialize a directory in the path specified by PROJECT-PATH.
+  "Run `cargo init' to initialize a directory in the path specified by PROJECT-PATH.
 If BIN is not nil, create a binary application, otherwise a library."
   (interactive "DProject path: ")
   (rustic-create-project project-path nil bin))
@@ -676,10 +676,10 @@ If BIN is not nil, create a binary application, otherwise a library."
   "Buffer name for run buffers.")
 
 (defvar rustic-run-arguments ""
-  "Holds arguments for 'cargo run', similar to `compilation-arguments`.")
+  "Holds arguments for `cargo run', similar to `compilation-arguments`.")
 
 (defvar rustic-run-history nil
-  "Holds previous arguments for 'cargo run', similar to `compile-history`.")
+  "Holds previous arguments for `cargo run', similar to `compile-history`.")
 
 (defvar rustic-cargo-run-mode-map
   (let ((map (make-sparse-keymap)))
@@ -692,7 +692,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 
 ;;;###autoload
 (defun rustic-cargo-run-command (&optional run-args)
-  "Start compilation process for 'cargo run' with optional RUN-ARGS."
+  "Start compilation process for `cargo run' with optional RUN-ARGS."
   (interactive)
   (rustic-compilation-process-live)
   (let* ((command (list (rustic-cargo-bin) rustic-cargo-run-exec-command))
@@ -704,7 +704,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 
 ;;;###autoload
 (defun rustic-cargo-run (&optional arg)
-  "Run 'cargo run'.
+  "Run `cargo run'.
 
 If ARG is not nil, use value as argument and store it in `rustic-run-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of
@@ -722,7 +722,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 ;;;###autoload
 (defun rustic-cargo-run-rerun (arg)
-  "Run 'cargo run' with `rustic-run-arguments'."
+  "Run `cargo run' with `rustic-run-arguments'."
   (interactive "P")
   (let ((default-directory (or rustic-compilation-directory default-directory)))
     (setq rustic-run-arguments
@@ -733,13 +733,13 @@ When calling this function from `rustic-popup-mode', always use the value of
     (rustic-cargo-run-command rustic-run-arguments)))
 
 (defun rustic--get-run-arguments ()
-  "Helper utility for getting arguments related to 'examples' directory."
+  "Helper utility for getting arguments related to `examples' directory."
   (let ((example-name (rustic-cargo-run-get-relative-example-name)))
     (when example-name
       (concat "--example " example-name))))
 
 (defun rustic-cargo-run-get-relative-example-name ()
-  "Run 'cargo run --example' if current buffer within a 'examples' directory."
+  "Run `cargo run --example' if current buffer within a `examples' directory."
   (let* ((buffer-project-root (rustic-buffer-crate))
          (current-filename (if buffer-file-name
                                buffer-file-name
@@ -777,7 +777,7 @@ in your project like `pwd'"
 
 ;;;###autoload
 (defun rustic-cargo-build (&optional arg)
-  "Run 'cargo build' for the current project, allow configuring
+  "Run `cargo build' for the current project, allow configuring
 `rustic-cargo-build-arguments' when prefix argument (C-u) is enabled."
   (interactive "P")
   (when arg
@@ -789,11 +789,11 @@ in your project like `pwd'"
                             (list :clippy-fix t)))
 
 (defvar rustic-clean-arguments nil
-  "Holds arguments for 'cargo clean', similar to `compilation-arguments`.")
+  "Holds arguments for `cargo clean', similar to `compilation-arguments`.")
 
 ;;;###autoload
 (defun rustic-cargo-clean (&optional arg)
-  "Run 'cargo clean' for the current project.
+  "Run `cargo clean' for the current project.
 
 If ARG is not nil, use value as argument and store it in `rustic-clean-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of
@@ -812,7 +812,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 ;;;###autoload
 (defun rustic-cargo-check (&optional arg)
-  "Run 'cargo check' for the current project, allow configuring
+  "Run `cargo check' for the current project, allow configuring
 `rustic-cargo-check-arguments' when prefix argument (C-u) is enabled."
   (interactive "P")
   (when arg
@@ -824,7 +824,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 ;;;###autoload
 (defun rustic-cargo-bench ()
-  "Run 'cargo bench' for the current project."
+  "Run `cargo bench' for the current project."
   (interactive)
   (rustic-run-cargo-command (list (rustic-cargo-bin) "bench")))
 
@@ -850,11 +850,11 @@ The documentation is built if necessary."
 ;;; cargo edit
 
 (defvar rustic-cargo-dependencies "*cargo-add-dependencies*"
-  "Buffer that is used for adding missing dependencies with 'cargo add'.")
+  "Buffer that is used for adding missing dependencies with `cargo add'.")
 
 ;;;###autoload
 (defun rustic-cargo-add (&optional arg)
-  "Add crate to Cargo.toml using 'cargo add'.
+  "Add crate to Cargo.toml using `cargo add'.
 If running with prefix command `C-u', read whole command from minibuffer."
   (interactive "P")
   (let* ((base (concat (rustic-cargo-bin) " add "))
@@ -955,7 +955,7 @@ as string."
 
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)
-  "Remove crate from Cargo.toml using 'cargo rm'.
+  "Remove crate from Cargo.toml using `cargo rm'.
 If running with prefix command `C-u', read whole command from minibuffer."
   (interactive "P")
   (let* ((command (if arg
@@ -967,7 +967,7 @@ If running with prefix command `C-u', read whole command from minibuffer."
 
 ;;;###autoload
 (defun rustic-cargo-upgrade (&optional arg)
-  "Upgrade dependencies as specified in the local manifest file using 'cargo upgrade'.
+  "Upgrade dependencies as specified in the local manifest file using `cargo upgrade'.
 If running with prefix command `C-u', read whole command from minibuffer."
   (interactive "P")
   (let* ((command (if arg
@@ -1009,7 +1009,7 @@ command from minibuffer."
   "Buffer name for install buffers.")
 
 (defvar rustic-install-arguments ""
-  "Holds arguments for 'cargo install', similar to `compilation-arguments`.
+  "Holds arguments for `cargo install', similar to `compilation-arguments`.
 Installs that are executed by `rustic-cargo-current-install' will also be
 stored in this variable.")
 
@@ -1028,7 +1028,7 @@ stored in this variable.")
 
 ;;;###autoload
 (defun rustic-cargo-install-rerun ()
-  "Run 'cargo install' with `rustic-install-arguments'."
+  "Run `cargo install' with `rustic-install-arguments'."
   (interactive)
   (rustic-compilation-start rustic-install-arguments
                               (list :buffer rustic-install-buffer-name
@@ -1037,7 +1037,7 @@ stored in this variable.")
                                     :directory rustic-install-project-dir)))
 ;;;###autoload
 (defun rustic-cargo-install (&optional arg)
-  "Install rust binary using 'cargo install'.
+  "Install rust binary using `cargo install'.
 If running with prefix command `C-u', read whole command from minibuffer."
   (interactive "P")
   (let* ((command (if arg

--- a/rustic-clippy.el
+++ b/rustic-clippy.el
@@ -8,17 +8,17 @@
 (require 'rustic-compile)
 
 (defcustom rustic-cargo-clippy-fix-args "--allow-dirty"
-  "Default arguments when running 'clippy --fix'."
+  "Default arguments when running `clippy --fix'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-default-clippy-arguments "--benches --tests --all-features"
-  "Default arguments when running clippy."
+  "Default arguments when running `clippy'."
   :type 'string
   :group 'rustic-cargo)
 
 (defcustom rustic-lints-arguments "-f custom_lints.toml clippy"
-  "Default arguments when running cargo-lints."
+  "Default arguments when running `cargo-lints'."
   :type 'string
   :group 'rustic-cargo)
 
@@ -29,7 +29,7 @@
   "Buffer name for clippy buffers.")
 
 (defvar rustic-clippy-arguments ""
-  "Holds arguments for 'cargo clippy', similar to `compilation-arguments`.")
+  "Holds arguments for `cargo clippy', similar to `compilation-arguments`.")
 
 (defvar rustic-cargo-clippy-mode-map
   (let ((map (make-sparse-keymap)))
@@ -60,7 +60,7 @@
 
 ;;;###autoload
 (defun rustic-cargo-lints ()
-  "Run cargo-lints with optional ARGS."
+  "Run `cargo-lints' with optional ARGS."
   (interactive)
   (let* ((command `(,(rustic-cargo-bin)
                     "lints"
@@ -72,7 +72,7 @@
 
 ;;;###autoload
 (defun rustic-cargo-clippy (&optional arg)
-  "Run 'cargo clippy'.
+  "Run `cargo clippy'.
 
 If ARG is not nil, use value as argument and store it in `rustic-clippy-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of
@@ -97,12 +97,12 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 ;;;###autoload
 (defun rustic-cargo-clippy-rerun ()
-  "Run 'cargo clippy' with `rustic-clippy-arguments'."
+  "Run `cargo clippy' with `rustic-clippy-arguments'."
   (interactive)
   (rustic-cargo-clippy-run :params rustic-clippy-arguments))
 
 (defun rustic-cargo-clippy-fix (&rest args)
-  "Run 'clippy fix'."
+  "Run `clippy fix'."
   (interactive)
   (rustic-cargo-clippy-run
    :params (concat "--fix "

--- a/rustic-comint.el
+++ b/rustic-comint.el
@@ -48,7 +48,7 @@ hit RET to send it to the program."
 
 ;;;###autoload
 (defun rustic-cargo-comint-run (&optional arg)
-  "Run 'cargo run' but for interactive programs.
+  "Run `cargo run' but for interactive programs.
 
 If ARG is not nil, use value as argument and store it in `rustic-run-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of

--- a/rustic-expand.el
+++ b/rustic-expand.el
@@ -16,7 +16,7 @@
   "Buffer name for expand buffers.")
 
 (defvar rustic-expand-arguments ""
-  "Holds arguments for 'cargo expand', similar to `compilation-arguments`.")
+  "Holds arguments for `cargo expand', similar to `compilation-arguments`.")
 
 (defvar rustic-cargo-expand-mode-map
   (let ((map (make-sparse-keymap)))
@@ -29,7 +29,7 @@
 
 ;;;###autoload
 (defun rustic-cargo-expand (&optional arg)
-  "Run 'cargo expand'.
+  "Run `cargo expand'.
 
 If ARG is not nil, use value as argument and store it in
 `rustic-expand-arguments'.  When calling this function from
@@ -42,7 +42,7 @@ If ARG is not nil, use value as argument and store it in
          (t ""))))
 
 (defun rustic-cargo-expand-command (&optional expand-args)
-  "Start compilation process for 'cargo expand' with optional EXPAND-ARGS."
+  "Start compilation process for `cargo expand' with optional EXPAND-ARGS."
   (rustic-compilation-process-live)
   (let* ((command (list (rustic-cargo-bin) "expand"))
          (c (append command (split-string (if expand-args expand-args ""))))
@@ -53,7 +53,7 @@ If ARG is not nil, use value as argument and store it in
 
 ;;;###autoload
 (defun rustic-cargo-expand-rerun ()
-  "Run 'cargo expand' with `rustic-expand-arguments'."
+  "Run `cargo expand' with `rustic-expand-arguments'."
   (interactive)
   (rustic-cargo-expand-command rustic-expand-arguments))
 

--- a/rustic-flycheck.el
+++ b/rustic-flycheck.el
@@ -21,8 +21,8 @@
 
 (defun rustic-flycheck-dirs-list (start end)
   "Return a list of directories from START (inclusive) to END (exclusive).
-E.g., if START is '/a/b/c/d' and END is '/a', return the list
-'(/a/b/c/d /a/b/c /a/b) in this order.
+E.g., if START is `/a/b/c/d' and END is `/a', return the list
+\\='(/a/b/c/d /a/b/c /a/b) in this order.
 START and END are strings representing file paths.  END should be
 above START in the file hierarchy; if not, the list stops at the
 root of the file hierarchy."

--- a/rustic-rustfix.el
+++ b/rustic-rustfix.el
@@ -19,7 +19,7 @@
 
 ;;;###autoload
 (defun rustic-rustfix ()
-  "Run 'cargo fix'."
+  "Run `cargo fix'."
   (interactive)
   (let* ((command (list (rustic-cargo-bin) "fix" "--allow-dirty"))
          (err-buf rustic-rustfix-buffer-name)

--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -44,17 +44,17 @@ VALUE is a string, an integer or a boolean."
 (defcustom rustic-format-trigger nil
   "This option allows you to automatically run rustfmt when saving
 or before using a compilation/cargo command.
-`on-compile' calls 'cargo fmt' in the directory that is returned by
+`on-compile' calls `cargo fmt' in the directory that is returned by
 the function used in `rustic-compile-directory-method'."
   :type '(choice (const :tag "Format buffer before saving." on-save)
-                 (const :tag "Run 'cargo fmt' before compilation." on-compile)
+                 (const :tag "Run `cargo fmt' before compilation." on-compile)
                  (const :tag "Don't format automatically." nil))
   :group 'rustic)
 
 (defcustom rustic-format-on-save-method 'rustic-format-file
   "Default function used for formatting before saving.
 This function will only be used when `rustic-format-trigger' is set
-to 'on-save."
+to \\='on-save."
   :type 'function
   :group 'rustic)
 
@@ -64,9 +64,9 @@ to 'on-save."
   :group 'rustic)
 
 (defcustom rustic-cargo-clippy-trigger-fix nil
-  "Whether to run 'clippy --fix' before build or run."
-  :type '(choice (const :tag "Run 'clippy --fix' before saving." on-save)
-                 (const :tag "Run 'clippy --fix' before compilation." on-compile)
+  "Whether to run `clippy --fix' before build or run."
+  :type '(choice (const :tag "Run `clippy --fix' before saving." on-save)
+                 (const :tag "Run `clippy --fix' before compilation." on-compile)
                  (const :tag "Don't fix automatically." nil))
   :group 'rustic)
 
@@ -338,7 +338,7 @@ This operation requires a nightly version of rustfmt.
 
 (defun rustic-format-dwim (beg end)
   "Format region if active, if not check if major mode is rustic
-and format file, or else run 'cargo fmt'."
+and format file, or else run `cargo fmt'."
   (interactive "r")
   (cond ((region-active-p)
          (rustic-format-region beg end))
@@ -398,7 +398,7 @@ This is basically a wrapper around `project--buffer-list'."
           #'rustic-maybe-format-before-compilation)
 
 (defun rustic-before-save-hook ()
-  "Automatically run 'clippy --fix' OR rustfmt before saving.
+  "Automatically run `clippy --fix' OR rustfmt before saving.
 
 Change `rustic-cargo-clippy-trigger-fix' and `rustic-format-trigger'
 to make use of these features.

--- a/rustic.el
+++ b/rustic.el
@@ -64,7 +64,7 @@
 ;;; workaround for with-temp-buffer not propagating the environment, as per
 ;;; https://github.com/magit/magit/pull/4169
 (defmacro rustic--with-temp-process-buffer (&rest body)
-  "Like `with-temp-buffer', but always propagate `process-environment' and 'exec-path'.
+  "Like `with-temp-buffer', but always propagate `process-environment' and `exec-path'.
 When those vars are buffer-local in the calling buffer, they are not
 propagated by `with-temp-buffer', so we explicitly ensure that
 happens, so that processes will be invoked consistently.  BODY is


### PR DESCRIPTION
Relates to #80.

Fixes warnings with the message

> `Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting)`

during native compilation of Rustic.

Additionally, added quotes for some cargo commands in documentation strings in a consistent way with how similar commands are quoted.

I checked the documentation from Emacs for some of the changes with `C-h` and they seemed to render fine.