### PR TITLE
Use `--all-targets` in cargo check/clippy/test argument defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ some toolchains when clippy isn't installed.  If you have problems try
 it with `rustup component add --toolchain nightly clippy`.
 
 You can change the parameters `rustic-default-clippy-arguments` that
-default to "--benches --tests --all-features".
+default to "--all-targets --all-features".
 
 ### auto-fixing before compilation
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -121,7 +121,7 @@ instead of applying the default arguments from `rustic-default-test-arguments'."
   :type '(list string)
   :group 'rustic-cargo)
 
-(defcustom rustic-cargo-check-arguments "--benches --tests --all-features"
+(defcustom rustic-cargo-check-arguments "--all-targets --all-features"
   "Default arguments when running `cargo check'."
   :type 'string
   :group 'rustic-cargo)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -111,7 +111,7 @@ instead of applying the default arguments from `rustic-default-test-arguments'."
   :type 'boolean
   :group 'rustic-cargo)
 
-(defcustom rustic-default-test-arguments "--benches --tests --all-features"
+(defcustom rustic-default-test-arguments "--all-targets --all-features"
   "Default arguments when running `cargo test'."
   :type 'string
   :group 'rustic-cargo)

--- a/rustic-clippy.el
+++ b/rustic-clippy.el
@@ -12,7 +12,7 @@
   :type 'string
   :group 'rustic-cargo)
 
-(defcustom rustic-default-clippy-arguments "--benches --tests --all-features"
+(defcustom rustic-default-clippy-arguments "--all-targets --all-features"
   "Default arguments when running `clippy'."
   :type 'string
   :group 'rustic-cargo)


### PR DESCRIPTION
This includes examples. I think it makes more sense as a default.