### PR TITLE
fix: Type of rustic-cargo-nextest-exec-command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *autoloads.el
 test/test-project/target
 test/test-project-single-crate/target
+.env

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -37,7 +37,7 @@
 
 (defcustom rustic-cargo-nextest-exec-command (list "nextest" "run")
   "Execute command to run nextest."
-  :type 'string
+  :type '(repeat string)
   :group 'rustic-cargo)
 
 (defcustom rustic-cargo-run-exec-command "run"


### PR DESCRIPTION
This commit enhances the `rustic-cargo-nextest-exec-command` customization option by changing its type from a single string to a list of strings.