### PR TITLE
ci: Bump Emacs 30 minor version to 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         emacs-version:
           - 28.2
           - 29.4
-          - 30.1
+          - 30.2
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
30.2 is now available.