### PR TITLE
Fix issues causing it to be impossible to use certain workspace config options with eglot

### DIFF
--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -123,7 +123,13 @@ with `lsp-rust-switch-server'."
                                      (when (symbolp (car mode))
                                        (eq (car mode) 'rust-mode)))
                                    eglot-server-programs)))))
-    (add-to-list 'eglot-server-programs `((rustic-mode :language-id "rust") . (eglot-rust-analyzer . ,rustic-analyzer-command)))))
+    (add-to-list 'eglot-server-programs
+                 (append '((rustic-mode :language-id "rust")
+                            eglot-rust-analyzer)
+                          rustic-analyzer-command
+                          (:initializationOptions
+                           (lambda (_)
+   				             (plist-get eglot-workspace-configuration :rust-analyzer)))))))
 
 (with-eval-after-load 'eglot
   (defclass eglot-rust-analyzer (eglot-lsp-server) ()


### PR DESCRIPTION
[rust-analyzer recommends passing the "rust-analyzer" section of the workspace config as `initializationOptions`](https://rust-analyzer.github.io/book/contributing/lsp-extensions.html#configuration-in-initializationoptions), as it needs to know the values of certain options during initialization.

rustic was not only not doing this, it was actually making this basically impossible to do by unconditionally overriding `eglot-initialization-options` to an implementation that ignored the user-specified initialization options.

fixes #105