### PR TITLE
Updated get_toolchain, it now retrieves active toolchain.

### DIFF
--- a/rustic-doc/convert.sh
+++ b/rustic-doc/convert.sh
@@ -2,7 +2,7 @@
 
 LUA_FILTER="$HOME/.local/bin/rustic-doc-filter.lua"
 function get_toolchain {
-    rustup show | sed -nr 's/(.*) \(default\)/\1/p' | head -n 1
+    rustup show active-toolchain | awk '{print $1}'
 }
 
 if [ "$1" = "" ] || [ "$1" = "--help"  ]; then


### PR DESCRIPTION
As per this [issue](https://github.com/emacs-rustic/rustic/issues/114), this pull requests updates the function which retrieves the active toolchain name as the previous approach is now outdated.