### PR TITLE
fix: resolve byte-compiler warnings

### DIFF
--- a/.github/workflows/byte-compile.yml
+++ b/.github/workflows/byte-compile.yml
@@ -1,0 +1,54 @@
+name: Byte-compile
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  byte-compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - 28.2
+          - 30.1
+          - snapshot
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Install dependencies
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(dolist (p '(rust-mode dash f s markdown-mode spinner xterm-color flycheck inheritenv polymode)) (unless (package-installed-p p) (package-install p)))"
+
+      - name: Byte-compile and load
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            -L . \
+            -f batch-byte-compile \
+            rustic.el rustic-babel.el rustic-cargo.el rustic-clippy.el \
+            rustic-comint.el rustic-compile.el rustic-doc.el \
+            rustic-expand.el rustic-flycheck.el rustic-interaction.el \
+            rustic-lsp.el rustic-playground.el rustic-popup.el \
+            rustic-rustfix.el rustic-rustfmt.el rustic-spellcheck.el
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            -L . \
+            --eval "(require 'rustic)"

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -336,7 +336,7 @@ executed with the parameter `:include'."
     (with-current-buffer (current-buffer)
       (save-excursion
         (dolist (b (mapcar (lambda (b) (if (symbolp b) (symbol-name b) b)) blocks))
-          (when-let ((c (rustic-babel-block-contents b)))
+          (when-let* ((c (rustic-babel-block-contents b)))
             (setq contents (concat contents c))))))
     contents))
 

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -277,7 +277,8 @@ Use VERSION, FEATURES and PATH."
     (concat name " = {" toml-entry "}")))
 
 (defun cargo-toml-dependencies (crate-versions crate-features crate-paths)
-  "Generate the [dependencies] section of a Cargo.toml file given crates and their versions & features."
+  "Generate the [dependencies] section of a Cargo.toml file.
+Use CRATE-VERSIONS, CRATE-FEATURES and CRATE-PATHS to build the section."
   (let ((dependencies ""))
     (dolist (crate-and-version crate-versions)
       (let* ((name (if (listp crate-and-version)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -891,7 +891,7 @@ If running with prefix command `C-u', read whole command from minibuffer."
   "Lookup and add missing dependencies to Cargo.toml.
 Adds all missing crates by default with latest version using lsp functionality.
 Supports both lsp-mode and egot.
-Use with 'C-u` to open prompt with missing crates."
+Use with \\='C-u' to open prompt with missing crates."
   (interactive)
   (-if-let (deps (rustic-cargo-find-missing-dependencies))
       (progn

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -742,8 +742,8 @@ When calling this function from `rustic-popup-mode', always use the value of
       nil)))
 
 ;;;###autoload
-(defun rustic-run-shell-command (&optional arg)
-  "Run an arbitrary shell command using ARG for the current project.
+(defun rustic-run-shell-command (&optional _arg)
+  "Run an arbitrary shell command for the current project.
 Example: use it to provide an environment variable to your
 application like this `env MYVAR=1 cargo run' so that it can read
 it at the runtime.  As a byproduct, you can run any shell command
@@ -887,7 +887,7 @@ If running with prefix command `C-u', read whole command from minibuffer."
                     (concat base (read-from-minibuffer "Crate: ")))))
     (rustic-run-cargo-command command)))
 
-(defun rustic-cargo-add-missing-dependencies (&optional arg)
+(defun rustic-cargo-add-missing-dependencies (&optional _arg)
   "Lookup and add missing dependencies to Cargo.toml.
 Adds all missing crates by default with latest version using lsp functionality.
 Supports both lsp-mode and egot.
@@ -911,7 +911,7 @@ them to Cargo.toml."
      (append (list :buffer rustic-cargo-dependencies
                    :no-default-dir t
                    :no-display t
-                   :sentinel (lambda (proc msg) ()))))))
+                   :sentinel (lambda (_proc _msg) ()))))))
 
 (defun rustic-cargo-find-missing-dependencies ()
   "Return missing dependencies using either lsp-mode or eglot/flymake

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -649,7 +649,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 
 ;;;###autoload
 (defun rustic-cargo-init (project-path &optional bin)
-  "Run `cargo init' to initialize a directory in the path specified by PROJECT-PATH.
+  "Run `cargo init' to initialize a directory in PROJECT-PATH.
 If BIN is not nil, create a binary application, otherwise a library."
   (interactive "DProject path: ")
   (rustic-create-project project-path nil bin))
@@ -819,9 +819,9 @@ When called with a prefix argument (C-u), prompt for a new command."
 (defun rustic-cargo-clean (&optional arg)
   "Run `cargo clean' for the current project.
 
-If ARG is not nil, use value as argument and store it in `rustic-clean-arguments'.
-When calling this function from `rustic-popup-mode', always use the value of
-`rustic-clean-arguments'."
+If ARG is not nil, use value as argument and store it in
+`rustic-clean-arguments'.  When calling this function from
+`rustic-popup-mode', always use the value of `rustic-clean-arguments'."
   (interactive "P")
   (rustic-run-cargo-command
    (-filter (lambda (s) (s-present? s))
@@ -991,7 +991,7 @@ If running with prefix command `C-u', read whole command from minibuffer."
 
 ;;;###autoload
 (defun rustic-cargo-upgrade (&optional arg)
-  "Upgrade dependencies as specified in the local manifest file using `cargo upgrade'.
+  "Upgrade dependencies in the local manifest file using `cargo upgrade'.
 If running with prefix command `C-u', read whole command from minibuffer."
   (interactive "P")
   (let* ((command (if arg

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -294,8 +294,8 @@ If ARG is not nil, use value as argument and store it in
 (defun rustic-cargo-test-dwim ()
   "Run test or mod at point. Otherwise run `rustic-cargo-test'."
   (interactive)
-  (if-let (test (or (rustic-cargo--get-current-fn-name)
-                    (rustic-cargo--get-current-mod)))
+  (if-let* ((test (or (rustic-cargo--get-current-fn-name)
+                      (rustic-cargo--get-current-mod))))
       (rustic-cargo-test)))
 
 (defconst rustic-cargo-mod-regexp
@@ -320,14 +320,14 @@ If ARG is not nil, use value as argument and store it in
   (save-excursion
     (progn
       (goto-char (line-end-position))
-      (when-let ((location (search-backward-regexp rustic-cargo-mod-regexp nil t)))
+      (when-let* ((location (search-backward-regexp rustic-cargo-mod-regexp nil t)))
         (cons location (match-string 1))))))
 
 (defun rustic-cargo--get-current-line-fn-name ()
   "Return cons with location and fn name from the current line or nil."
   (save-excursion
     (goto-char (line-beginning-position))
-    (when-let ((location (search-forward-regexp rustic-cargo-fn-regexp (line-end-position) t)))
+    (when-let* ((location (search-forward-regexp rustic-cargo-fn-regexp (line-end-position) t)))
       (cons location (match-string 1)))))
 
 (defun rustic-cargo--get-current-fn-name ()

--- a/rustic-clippy.el
+++ b/rustic-clippy.el
@@ -110,7 +110,7 @@ If ARG is not nil, use value as argument and store it in
                    rustic-default-clippy-arguments)
    :no-save (plist-get args :no-save)
    :silent t
-   :sentinel (lambda (proc msg)
+   :sentinel (lambda (proc _msg)
                (while (eq (process-status proc) 'run)
                  (sit-for 0.1))
                (if (zerop (process-exit-status proc))

--- a/rustic-clippy.el
+++ b/rustic-clippy.el
@@ -74,9 +74,9 @@
 (defun rustic-cargo-clippy (&optional arg)
   "Run `cargo clippy'.
 
-If ARG is not nil, use value as argument and store it in `rustic-clippy-arguments'.
-When calling this function from `rustic-popup-mode', always use the value of
-`rustic-clippy-arguments'."
+If ARG is not nil, use value as argument and store it in
+`rustic-clippy-arguments'.  When calling this function from
+`rustic-popup-mode', always use the value of `rustic-clippy-arguments'."
   (interactive "P")
   (rustic-cargo-clippy-run
    :params (cond (arg

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -447,7 +447,7 @@ Buffers are formatted after saving if turned on by `rustic-format-trigger'."
               (rustic-maybe-format-after-save buffer))))))))
 
 (defun rustic-compile-goto-error-hook (orig-fun &rest args)
-  "Provide possibility use `compile-goto-error' on line numbers in compilation buffers.
+  "Allow `compile-goto-error' on line numbers in compilation buffers.
 This hook checks if there's a line number at the beginning of the
 current line in an error section."
   (-if-let* ((rustic-p (derived-mode-p 'rustic-compilation-mode))

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -434,7 +434,7 @@ is called `std::option::Option' in the docs."
   "Thing-at-point if using eglot.
 If anything goes wrong, return DEFAULT."
   (interactive)
-  (if-let ((content (jsonrpc-request
+  (if-let* ((content (jsonrpc-request
                      (eglot--current-server-or-lose)
                      :textDocument/hover (eglot--TextDocumentPositionParams)))
            ;; text-name is the qualified name, but it sometimes doesn't correspond to the folder structure.
@@ -448,7 +448,7 @@ If anything goes wrong, return DEFAULT."
 (defun rustic-doc--thing-at-point-lsp-mode (default)
   "Thing at point if using lsp-mode.
 If anything goes wrong, return DEFAULT."
-  (if-let ((active (boundp 'lsp-mode))
+  (if-let* ((active (boundp 'lsp-mode))
            (lsp-content (when (alist-get 'lsp-mode minor-mode-alist)
                           (-some->> (lsp--text-document-position-params)
                             (lsp--make-request "textDocument/hover")

--- a/rustic-flycheck.el
+++ b/rustic-flycheck.el
@@ -10,12 +10,14 @@
 (require 'rustic)
 
 (defcustom rustic-flycheck-clippy-params-stable "--message-format=json"
-  "Parameters for the flycheck clippy checker `rustic-clippy' when active toolchain is stable."
+  "Parameters for the flycheck clippy checker `rustic-clippy'.
+Used when the active toolchain is stable."
   :type 'string
   :group 'rustic-flycheck)
 
 (defcustom rustic-flycheck-clippy-params-nightly "--message-format=json -Zunstable-options"
-  "Parameters for the flycheck clippy checker `rustic-clippy' when active toolchain is nightly."
+  "Parameters for the flycheck clippy checker `rustic-clippy'.
+Used when the active toolchain is nightly."
   :type 'string
   :group 'rustic-flycheck)
 

--- a/rustic-interaction.el
+++ b/rustic-interaction.el
@@ -16,8 +16,8 @@
 
 ;;;###autoload
 (defun rustic-open-dependency-file ()
-  "Open the 'Cargo.toml' file at the project root if the current buffer is
-visiting a project."
+  "Open the \\='Cargo.toml' file at the project root.
+Only act if the current buffer is visiting a project."
   (interactive)
   (let ((workspace (rustic-buffer-crate t)))
     (if workspace

--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -87,8 +87,9 @@ in, e.g. your home directory."
 (declare-function lsp-workspace-root "lsp-mode" (&optional path))
 
 (defun rustic-lsp-mode-setup ()
-  "When changing the `lsp-rust-server', it's also necessary to update the priorities
-with `lsp-rust-switch-server'."
+  "Set up `lsp-mode' for rustic.
+When changing the `lsp-rust-server', it is also necessary to update
+the priorities with `lsp-rust-switch-server'."
   (require 'lsp-rust)
   (require 'lsp-modeline)
   ;; TODO: Do we still need this ? Seems to break stuff (hlissner/doom-emacs/issues/4070)

--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -176,7 +176,7 @@ and it's `cdr' is a list of arguments."
               (kill-buffer proc-buffer)
               (message "Formatted buffer with rustfmt."))
           (goto-char (point-min))
-          (when-let ((file (buffer-file-name next-error-last-buffer)))
+          (when-let* ((file (buffer-file-name next-error-last-buffer)))
             (save-excursion
               (save-match-data
                 (when (search-forward "<stdin>" nil t)
@@ -187,7 +187,7 @@ and it's `cdr' is a list of arguments."
           (message "Rustfmt error."))))
 
     ;; rustfmt warnings
-    (when-let ((b (process-get proc 'command-buf)))
+    (when-let* ((b (process-get proc 'command-buf)))
       (when (process-get proc 'command-buf)
         (let ((warnings ""))
           (with-current-buffer b
@@ -357,7 +357,7 @@ different emacs versions."
 (defun rustic-project-buffer-list ()
   "Return a list of the buffers belonging to the current project.
 This is basically a wrapper around `project--buffer-list'."
-  (when-let ((pr (project-current)))
+  (when-let* ((pr (project-current)))
     (if (fboundp 'project--buffer-list)
         (project--buffer-list pr)
       ;; Like the above function but for releases before Emacs 28.

--- a/rustic.el
+++ b/rustic.el
@@ -71,8 +71,8 @@ propagated by `with-temp-buffer', so we explicitly ensure that
 happens, so that processes will be invoked consistently.  BODY is
 as for that macro."
   (declare (indent 0) (debug (body)))
-  (let ((p (cl-gensym))
-        (e (cl-gensym)))
+  (let ((p (gensym))
+        (e (gensym)))
     `(let ((,p process-environment)
            (,e exec-path))
        (with-temp-buffer

--- a/rustic.el
+++ b/rustic.el
@@ -64,7 +64,8 @@
 ;;; workaround for with-temp-buffer not propagating the environment, as per
 ;;; https://github.com/magit/magit/pull/4169
 (defmacro rustic--with-temp-process-buffer (&rest body)
-  "Like `with-temp-buffer', but always propagate `process-environment' and `exec-path'.
+  "Like `with-temp-buffer', but always propagate the environment variables.
+The `process-environment' and `exec-path' variables are propagated.
 When those vars are buffer-local in the calling buffer, they are not
 propagated by `with-temp-buffer', so we explicitly ensure that
 happens, so that processes will be invoked consistently.  BODY is


### PR DESCRIPTION
## Summary

This PR fixes byte-compiler warnings in the rustic source files. Each
warning type is addressed in its own commit, and only behaviour-preserving
changes were made. Warnings whose fix would change behaviour are left as-is.

The package minimum is Emacs 28.2, so the obsolescence fixes use
replacements available at or below that version (`gensym`, `if-let*`,
`when-let*`, all available since Emacs 26.1).

## Fixed warnings (behaviour-preserving)

- **docstring wider than 80 characters**: reflowed docstrings in
  `rustic.el`, `rustic-babel.el`, `rustic-cargo.el`, `rustic-clippy.el`,
  `rustic-compile.el`, `rustic-lsp.el`, `rustic-flycheck.el`.
- **docstring has wrong usage of unescaped single quotes**: escaped the
  literal leading single quotes in `rustic-cargo.el` and
  `rustic-interaction.el` using `\='`.
- **`cl-gensym` is obsolete (31.1)**: replaced with `gensym` (available
  since 26.1) in `rustic.el`.
- **`if-let` / `when-let` are obsolete (31.1)**: replaced with `if-let*` /
  `when-let*` (available since 26.1) in `rustic-babel.el`,
  `rustic-cargo.el`, `rustic-doc.el`, `rustic-rustfmt.el`.
- **unused lexical argument**: underscore-prefixed unused function and
  lambda parameters in `rustic-cargo.el` and `rustic-clippy.el`.

## CI

Adds a `byte-compile.yml` workflow that byte-compiles and loads every
source file on Emacs 28.2 (the package minimum), 30.1, and snapshot, with
dependencies installed from MELPA. It does not use `-Werror` because the
residual warnings below come from optional, external integrations.

## Residual warnings (left intentionally)

These would require behaviour changes or depend on optional/external
packages, so they are not addressed here:

- `replace-buffer-contents` -> `replace-region-contents` (behaviour change;
  `rustic-rustfmt.el`).
- `project-roots` -> `project-root` (behaviour change; `rustic-rustfmt.el`).
- `defcustom` for `rustic-popup-commands`: `list` without arguments
  (`:type` widget change; `rustic-popup.el`).
- value from call to `f-exists?` is unused (`rustic-doc.el`): removing it
  would change behaviour.
- assignment/reference to free variables tied to optional integrations
  (`rust-*` save hooks, `result`, `command`, `eglot`,
  `flymake--diagnostics-buffer-source`, `flycheck-error-list-buffer`,
  `poly-*`, `rustic-compilation-workspace`).
- functions not known to be defined, from optional integrations
  (`inheritenv-apply`, `define-polymode`/`define-innermode`/`define-hostmode`,
  `lsp-*`, `eglot-*`, `flycheck-*`, `flymake-*`, `jsonrpc-request`,
  `-semver-*`, `rustic-cargo-bin` forward reference).
- `global/dynamic var 'eglot' lacks a prefix` (external dynamic var).
